### PR TITLE
refactor config template

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -17,7 +17,11 @@ LABEL io.k8s.description="Mattermost is an open source, self-hosted Slack-altern
 
 RUN yum update -y && yum install -y tar nc && yum clean all
 
-RUN curl -LO https://releases.mattermost.com/3.6.0/mattermost-team-3.6.0-linux-amd64.tar.gz && tar -xf mattermost-team-3.6.0-linux-amd64.tar.gz && rm -f mattermost-team-3.6.0-linux-amd64.tar.gz
+RUN sh -x && \
+  curl -LO https://releases.mattermost.com/3.6.0/mattermost-team-3.6.0-linux-amd64.tar.gz && \
+  tar -xf mattermost-team-3.6.0-linux-amd64.tar.gz && \
+  rm -f mattermost-team-3.6.0-linux-amd64.tar.gz
+COPY config.template.json /
 
 VOLUME ["/mattermost/config"]
 VOLUME ["/mattermost/logs"]

--- a/app/docker-entry.sh
+++ b/app/docker-entry.sh
@@ -5,27 +5,29 @@ DB_PORT_5432_TCP_PORT=${DB_PORT_5432_TCP_PORT:-5432}
 MM_USERNAME=${MM_USERNAME:-mmuser}
 MM_PASSWORD=${MM_PASSWORD:-mmuser_password}
 MM_DBNAME=${MM_DBNAME:-mattermost}
-MM_MIGRATE=${MM_MIGRATE:-no}
-
-if [[ $MM_MIGRATE == "no" ]]; then 
-curl https://raw.githubusercontent.com/syamgk/mattermost-docker/master/app/config.template.json > $config;
-fi
 
 echo -ne "Configure database connection..."
-sed -Ei "s/DB_HOST/$DB_HOST/" $config
-sed -Ei "s/DB_PORT/$DB_PORT_5432_TCP_PORT/" $config
-sed -Ei "s/MM_USERNAME/$MM_USERNAME/" $config
-sed -Ei "s/MM_PASSWORD/$MM_PASSWORD/" $config
-sed -Ei "s/MM_DBNAME/$MM_DBNAME/" $config
-echo OK
+if [[ ! -f $config ]]; then
+  cp /config.template.json $config
+  sed -Ei "s/DB_HOST/$DB_HOST/" $config
+  sed -Ei "s/DB_PORT/$DB_PORT_5432_TCP_PORT/" $config
+  sed -Ei "s/MM_USERNAME/$MM_USERNAME/" $config
+  sed -Ei "s/MM_PASSWORD/$MM_PASSWORD/" $config
+  sed -Ei "s/MM_DBNAME/$MM_DBNAME/" $config
+  echo OK
+else
+  echo SKIP
+fi
 
 echo "Wait until database $DB_HOST:$DB_PORT_5432_TCP_PORT is ready..."
 until nc $DB_HOST $DB_PORT_5432_TCP_PORT
 do
     sleep 1
 done
+
 # Wait to avoid "panic: Failed to open sql connection pq: the database system is starting up"
 sleep 1
+
 echo "Starting platform"
 cd /mattermost/bin
 ./platform $*


### PR DESCRIPTION
This refactors the way the config template is used

Instead of fetching it from github at runtime, we copy it into the container at build time